### PR TITLE
use `next/font`

### DIFF
--- a/lib/chakraTheme.ts
+++ b/lib/chakraTheme.ts
@@ -1,9 +1,16 @@
 import { extendTheme } from '@chakra-ui/react';
+import { Noto_Sans_JP } from 'next/font/google';
+
+const notoSansJp = Noto_Sans_JP({
+  weight: ['400', '700'],
+  subsets: ['latin'],
+  fallback: ['system-ui', 'sans-serif'],
+});
 
 const theme = extendTheme({
   fonts: {
-    heading: 'Noto Sans JP, system-ui, sans-serif',
-    body: 'Noto Sans JP, system-ui, sans-serif',
+    heading: notoSansJp.style.fontFamily,
+    body: notoSansJp.style.fontFamily,
   },
   lineHeights: {
     base: 1.8,

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -20,10 +20,6 @@ class MyDocument extends Document {
       <Html lang="ja">
         <Head>
           <link
-            href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP&display=optional"
-            rel="stylesheet"
-          />
-          <link
             rel="apple-touch-icon"
             sizes="180x180"
             href="/apple-touch-icon.png"


### PR DESCRIPTION
close https://github.com/thinceller/blog.thinceller.net/issues/682

see:
- [Optimizing: Fonts | Next.js](https://nextjs.org/docs/app/building-your-application/optimizing/fonts)
- https://github.com/chakra-ui/chakra-ui/discussions/7235#discussioncomment-4685189
