### PR TITLE
feat: add RSS and Atom feed support

### DIFF
--- a/app/atom.xml/route.ts
+++ b/app/atom.xml/route.ts
@@ -1,13 +1,18 @@
 import { generateAtomFeed } from '@/lib/rss';
 
 export async function GET() {
-  const feed = generateAtomFeed();
+  try {
+    const feed = generateAtomFeed();
 
-  return new Response(feed, {
-    headers: {
-      'Content-Type': 'application/atom+xml; charset=utf-8',
-      'Cache-Control':
-        'max-age=3600, s-maxage=3600, stale-while-revalidate=86400',
-    },
-  });
+    return new Response(feed, {
+      headers: {
+        'Content-Type': 'application/atom+xml; charset=utf-8',
+        'Cache-Control':
+          'max-age=3600, s-maxage=3600, stale-while-revalidate=86400',
+      },
+    });
+  } catch (error) {
+    console.error('Failed to generate Atom feed:', error);
+    return new Response('Internal Server Error', { status: 500 });
+  }
 }

--- a/app/atom.xml/route.ts
+++ b/app/atom.xml/route.ts
@@ -1,0 +1,13 @@
+import { generateAtomFeed } from '@/lib/rss';
+
+export async function GET() {
+  const feed = generateAtomFeed();
+
+  return new Response(feed, {
+    headers: {
+      'Content-Type': 'application/atom+xml; charset=utf-8',
+      'Cache-Control':
+        'max-age=3600, s-maxage=3600, stale-while-revalidate=86400',
+    },
+  });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,6 +25,16 @@ export const metadata: Metadata = {
     creator: '@thinceller_dev',
     card: 'summary_large_image',
   },
+  alternates: {
+    types: {
+      'application/rss+xml': [
+        { url: '/rss.xml', title: `${BLOG_NAME} RSS Feed` },
+      ],
+      'application/atom+xml': [
+        { url: '/atom.xml', title: `${BLOG_NAME} Atom Feed` },
+      ],
+    },
+  },
 };
 
 export default function RootLayout({

--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -1,0 +1,13 @@
+import { generateRSSFeed } from '@/lib/rss';
+
+export async function GET() {
+  const feed = generateRSSFeed();
+
+  return new Response(feed, {
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+      'Cache-Control':
+        'max-age=3600, s-maxage=3600, stale-while-revalidate=86400',
+    },
+  });
+}

--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -1,13 +1,18 @@
 import { generateRSSFeed } from '@/lib/rss';
 
 export async function GET() {
-  const feed = generateRSSFeed();
+  try {
+    const feed = generateRSSFeed();
 
-  return new Response(feed, {
-    headers: {
-      'Content-Type': 'application/rss+xml; charset=utf-8',
-      'Cache-Control':
-        'max-age=3600, s-maxage=3600, stale-while-revalidate=86400',
-    },
-  });
+    return new Response(feed, {
+      headers: {
+        'Content-Type': 'application/rss+xml; charset=utf-8',
+        'Cache-Control':
+          'max-age=3600, s-maxage=3600, stale-while-revalidate=86400',
+      },
+    });
+  } catch (error) {
+    console.error('Failed to generate RSS feed:', error);
+    return new Response('Internal Server Error', { status: 500 });
+  }
 }

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,4 +1,5 @@
 import { faGithub, faTwitter } from '@fortawesome/free-brands-svg-icons';
+import { faRss } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import type { FC } from 'react';
 
@@ -29,6 +30,9 @@ export const Footer: FC = () => {
               icon={faGithub}
               className="text-xl text-gray-400"
             />
+          </a>
+          <a href="/rss.xml" aria-label="RSS Feed">
+            <FontAwesomeIcon icon={faRss} className="text-xl text-gray-400" />
           </a>
         </div>
       </div>

--- a/lib/rss.ts
+++ b/lib/rss.ts
@@ -2,7 +2,15 @@ import { Feed } from 'feed';
 import { BLOG_AUTHOR, BLOG_NAME, BLOG_URL } from './constants';
 import { getAllPosts } from './post';
 
-function createFeedInstance(posts: ReturnType<typeof getAllPosts>): Feed {
+function createFeedInstance(
+  posts: Array<{
+    title: string;
+    description: string;
+    slug: string;
+    publishedTime: string;
+    modifiedTime: string;
+  }>,
+): Feed {
   const siteURL = BLOG_URL;
   const year = new Date().getFullYear();
 

--- a/lib/rss.ts
+++ b/lib/rss.ts
@@ -1,0 +1,126 @@
+import { Feed } from 'feed';
+import { BLOG_AUTHOR, BLOG_NAME, BLOG_URL } from './constants';
+import { getAllPosts } from './post';
+
+export function generateRSSFeed(): string {
+  const posts = getAllPosts([
+    'title',
+    'description',
+    'slug',
+    'publishedTime',
+    'modifiedTime',
+  ]);
+
+  const siteURL = BLOG_URL;
+  const feedURL = `${siteURL}/rss.xml`;
+  const year = new Date().getFullYear();
+
+  const feed = new Feed({
+    title: BLOG_NAME,
+    description: `${BLOG_AUTHOR}の技術ブログ`,
+    id: siteURL,
+    link: siteURL,
+    language: 'ja',
+    image: `${siteURL}/favicon.ico`,
+    favicon: `${siteURL}/favicon.ico`,
+    copyright: `© ${year} ${BLOG_AUTHOR}`,
+    updated: posts[0]?.modifiedTime
+      ? new Date(posts[0].modifiedTime)
+      : new Date(posts[0]?.publishedTime || new Date()),
+    generator: 'Feed for Node.js',
+    feedLinks: {
+      rss2: feedURL,
+      atom: `${siteURL}/atom.xml`,
+    },
+    author: {
+      name: BLOG_AUTHOR,
+      link: siteURL,
+    },
+  });
+
+  for (const post of posts) {
+    const url = `${siteURL}/posts/${post.slug}`;
+    const date = new Date(post.publishedTime);
+    const modifiedDate = post.modifiedTime
+      ? new Date(post.modifiedTime)
+      : undefined;
+
+    feed.addItem({
+      title: post.title,
+      id: url,
+      link: url,
+      description: post.description,
+      date: modifiedDate || date,
+      published: date,
+      author: [
+        {
+          name: BLOG_AUTHOR,
+          link: siteURL,
+        },
+      ],
+    });
+  }
+
+  return feed.rss2();
+}
+
+export function generateAtomFeed(): string {
+  const posts = getAllPosts([
+    'title',
+    'description',
+    'slug',
+    'publishedTime',
+    'modifiedTime',
+  ]);
+
+  const siteURL = BLOG_URL;
+  const year = new Date().getFullYear();
+
+  const feed = new Feed({
+    title: BLOG_NAME,
+    description: `${BLOG_AUTHOR}の技術ブログ`,
+    id: siteURL,
+    link: siteURL,
+    language: 'ja',
+    image: `${siteURL}/favicon.ico`,
+    favicon: `${siteURL}/favicon.ico`,
+    copyright: `© ${year} ${BLOG_AUTHOR}`,
+    updated: posts[0]?.modifiedTime
+      ? new Date(posts[0].modifiedTime)
+      : new Date(posts[0]?.publishedTime || new Date()),
+    generator: 'Feed for Node.js',
+    feedLinks: {
+      rss2: `${siteURL}/rss.xml`,
+      atom: `${siteURL}/atom.xml`,
+    },
+    author: {
+      name: BLOG_AUTHOR,
+      link: siteURL,
+    },
+  });
+
+  for (const post of posts) {
+    const url = `${siteURL}/posts/${post.slug}`;
+    const date = new Date(post.publishedTime);
+    const modifiedDate = post.modifiedTime
+      ? new Date(post.modifiedTime)
+      : undefined;
+
+    feed.addItem({
+      title: post.title,
+      id: url,
+      link: url,
+      description: post.description,
+      date: modifiedDate || date,
+      published: date,
+      author: [
+        {
+          name: BLOG_AUTHOR,
+          link: siteURL,
+        },
+      ],
+    });
+  }
+
+  return feed.atom1();
+}

--- a/lib/rss.ts
+++ b/lib/rss.ts
@@ -2,79 +2,14 @@ import { Feed } from 'feed';
 import { BLOG_AUTHOR, BLOG_NAME, BLOG_URL } from './constants';
 import { getAllPosts } from './post';
 
-export function generateRSSFeed(): string {
-  const posts = getAllPosts([
-    'title',
-    'description',
-    'slug',
-    'publishedTime',
-    'modifiedTime',
-  ]);
-
+function createFeedInstance(posts: ReturnType<typeof getAllPosts>): Feed {
   const siteURL = BLOG_URL;
-  const feedURL = `${siteURL}/rss.xml`;
   const year = new Date().getFullYear();
 
-  const feed = new Feed({
-    title: BLOG_NAME,
-    description: `${BLOG_AUTHOR}の技術ブログ`,
-    id: siteURL,
-    link: siteURL,
-    language: 'ja',
-    image: `${siteURL}/favicon.ico`,
-    favicon: `${siteURL}/favicon.ico`,
-    copyright: `© ${year} ${BLOG_AUTHOR}`,
-    updated: posts[0]?.modifiedTime
-      ? new Date(posts[0].modifiedTime)
-      : new Date(posts[0]?.publishedTime || new Date()),
-    generator: 'Feed for Node.js',
-    feedLinks: {
-      rss2: feedURL,
-      atom: `${siteURL}/atom.xml`,
-    },
-    author: {
-      name: BLOG_AUTHOR,
-      link: siteURL,
-    },
-  });
-
-  for (const post of posts) {
-    const url = `${siteURL}/posts/${post.slug}`;
-    const date = new Date(post.publishedTime);
-    const modifiedDate = post.modifiedTime
-      ? new Date(post.modifiedTime)
-      : undefined;
-
-    feed.addItem({
-      title: post.title,
-      id: url,
-      link: url,
-      description: post.description,
-      date: modifiedDate || date,
-      published: date,
-      author: [
-        {
-          name: BLOG_AUTHOR,
-          link: siteURL,
-        },
-      ],
-    });
+  // Validate required data
+  if (!siteURL || !BLOG_NAME || !BLOG_AUTHOR) {
+    throw new Error('Missing required configuration for feed generation');
   }
-
-  return feed.rss2();
-}
-
-export function generateAtomFeed(): string {
-  const posts = getAllPosts([
-    'title',
-    'description',
-    'slug',
-    'publishedTime',
-    'modifiedTime',
-  ]);
-
-  const siteURL = BLOG_URL;
-  const year = new Date().getFullYear();
 
   const feed = new Feed({
     title: BLOG_NAME,
@@ -100,17 +35,27 @@ export function generateAtomFeed(): string {
   });
 
   for (const post of posts) {
+    // Validate post data
+    if (!post.title || !post.slug || !post.publishedTime) {
+      console.warn(`Skipping invalid post: ${JSON.stringify(post)}`);
+      continue;
+    }
+
     const url = `${siteURL}/posts/${post.slug}`;
     const date = new Date(post.publishedTime);
     const modifiedDate = post.modifiedTime
       ? new Date(post.modifiedTime)
       : undefined;
 
+    // Add excerpt as content if description is available
+    const content = post.description ? `<p>${post.description}</p>` : undefined;
+
     feed.addItem({
       title: post.title,
       id: url,
       link: url,
       description: post.description,
+      content,
       date: modifiedDate || date,
       published: date,
       author: [
@@ -122,5 +67,31 @@ export function generateAtomFeed(): string {
     });
   }
 
+  return feed;
+}
+
+export function generateRSSFeed(): string {
+  const posts = getAllPosts([
+    'title',
+    'description',
+    'slug',
+    'publishedTime',
+    'modifiedTime',
+  ]);
+
+  const feed = createFeedInstance(posts);
+  return feed.rss2();
+}
+
+export function generateAtomFeed(): string {
+  const posts = getAllPosts([
+    'title',
+    'description',
+    'slug',
+    'publishedTime',
+    'modifiedTime',
+  ]);
+
+  const feed = createFeedInstance(posts);
   return feed.atom1();
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@shikijs/rehype": "3.4.2",
     "@shikijs/themes": "3.4.2",
     "dayjs": "1.11.13",
+    "feed": "5.1.0",
     "gray-matter": "4.0.3",
     "next": "15.3.3",
     "react": "19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       dayjs:
         specifier: 1.11.13
         version: 1.11.13
+      feed:
+        specifier: 5.1.0
+        version: 5.1.0
       gray-matter:
         specifier: 4.0.3
         version: 4.0.3
@@ -2321,6 +2324,10 @@ packages:
       picomatch:
         optional: true
 
+  feed@5.1.0:
+    resolution: {integrity: sha512-qGNhgYygnefSkAHHrNHqC7p3R8J0/xQDS/cYUud8er/qD9EFGWyCdUDfULHTJQN1d3H3WprzVwMc9MfB4J50Wg==}
+    engines: {node: '>=20', pnpm: '>=10'}
+
   file-entry-cache@10.1.0:
     resolution: {integrity: sha512-Et/ex6smi3wOOB+n5mek+Grf7P2AxZR5ueqRUvAAn4qkyatXi3cUC1cuQXVkX0VlzBVsN4BkWJFmY/fYiRTdww==}
 
@@ -3656,6 +3663,9 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  sax@1.4.1:
+    resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
+
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
 
@@ -4344,6 +4354,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xml-js@1.6.11:
+    resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
+    hasBin: true
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -7503,6 +7517,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.2
 
+  feed@5.1.0:
+    dependencies:
+      xml-js: 1.6.11
+
   file-entry-cache@10.1.0:
     dependencies:
       flat-cache: 6.1.9
@@ -9205,6 +9223,8 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  sax@1.4.1: {}
+
   scheduler@0.26.0: {}
 
   section-matter@1.0.0:
@@ -10261,6 +10281,10 @@ snapshots:
   ws@7.5.10: {}
 
   ws@8.18.0: {}
+
+  xml-js@1.6.11:
+    dependencies:
+      sax: 1.4.1
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
## Summary
- Add RSS 2.0 and Atom 1.0 feed generation for the blog
- Enable feed autodiscovery through metadata alternates
- Add RSS icon link in the footer for easy feed subscription

## Changes
- **New Routes**: Added `/rss.xml` and `/atom.xml` route handlers that generate feeds dynamically
- **Feed Generation**: Implemented `generateRSSFeed()` and `generateAtomFeed()` functions using the `feed` npm package
- **Autodiscovery**: Added feed alternates to the root layout metadata for browser feed discovery
- **UI Enhancement**: Added RSS icon to the footer linking to the RSS feed
- **Dependencies**: Added `feed` package (v5.1.0) for feed generation

## Implementation Details
- Feeds include all blog posts sorted by date with proper metadata
- Both RSS 2.0 and Atom 1.0 formats are supported
- Feed responses include appropriate cache headers (1 hour cache)
- Feed content is generated from existing blog post data (title, description, dates)

## Test plan
- [ ] Visit `/rss.xml` and verify valid RSS 2.0 XML is returned
- [ ] Visit `/atom.xml` and verify valid Atom 1.0 XML is returned
- [ ] Check that RSS icon appears in footer and links correctly
- [ ] Test feed in an RSS reader to ensure posts display properly
- [ ] Verify browser feed autodiscovery works (RSS icon in address bar)

🤖 Generated with [Claude Code](https://claude.ai/code)