### PR TITLE
fix: force static generation for RSS and Atom feeds

### DIFF
--- a/app/atom.xml/route.ts
+++ b/app/atom.xml/route.ts
@@ -1,5 +1,7 @@
 import { generateAtomFeed } from '@/lib/rss';
 
+export const dynamic = 'force-static';
+
 export async function GET() {
   try {
     const feed = generateAtomFeed();

--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -1,5 +1,7 @@
 import { generateRSSFeed } from '@/lib/rss';
 
+export const dynamic = 'force-static';
+
 export async function GET() {
   try {
     const feed = generateRSSFeed();


### PR DESCRIPTION
## Summary
- Add `export const dynamic = 'force-static'` to RSS and Atom route handlers to force static generation at build time
- This fixes the internal server error that occurred in production on Cloudflare Workers

## Problem
The RSS and Atom feeds were being dynamically rendered in production, which caused internal server errors on Cloudflare Workers.

## Solution
By adding `export const dynamic = 'force-static'` to both route handlers, Next.js now generates these routes as static files during the build process, preventing runtime errors.

## Test plan
- [x] Build the application locally with `pnpm build`
- [x] Verify that `/rss.xml` and `/atom.xml` are marked as static (○) in the build output
- [x] Deploy to production and verify feeds are accessible without errors

🤖 Generated with [Claude Code](https://claude.ai/code)