### PR TITLE
fix: implement singleton pattern for Shiki highlighter

### DIFF
--- a/lib/mdx.tsx
+++ b/lib/mdx.tsx
@@ -12,7 +12,7 @@ import matter from 'gray-matter';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import rehypeCodeTitles from 'rehype-code-titles';
 import rehypeSlug from 'rehype-slug';
-import { createHighlighter } from './shiki';
+import { getHighlighter } from './shiki';
 
 const frontMatterSchema = v.object({
   title: v.string(),
@@ -47,7 +47,7 @@ export const getPostBySlug = async (slug: string): Promise<MDXPostData> => {
       rehypeCodeTitles,
       [
         rehypeShikiFromHighlighter,
-        await createHighlighter(),
+        await getHighlighter(),
         {
           theme: 'night-owl',
           transformers: [

--- a/lib/shiki.ts
+++ b/lib/shiki.ts
@@ -1,8 +1,15 @@
 import { createHighlighterCore } from 'shiki/core';
+import type { HighlighterCore } from 'shiki/core';
 import { createOnigurumaEngine } from 'shiki/engine/oniguruma';
 
-export const createHighlighter = async () => {
-  const highlighter = await createHighlighterCore({
+let highlighterInstance: HighlighterCore | null = null;
+
+export const getHighlighter = async () => {
+  if (highlighterInstance) {
+    return highlighterInstance;
+  }
+
+  highlighterInstance = await createHighlighterCore({
     themes: [import('@shikijs/themes/night-owl')],
     langs: [
       import('@shikijs/langs/javascript'),
@@ -20,5 +27,5 @@ export const createHighlighter = async () => {
     engine: createOnigurumaEngine(() => import('shiki/wasm')),
   });
 
-  return highlighter;
+  return highlighterInstance;
 };


### PR DESCRIPTION
close #983

## Summary
- Implemented singleton pattern for Shiki highlighter to reduce multiple instance creation
- Changed `createHighlighter` to `getHighlighter` which reuses the same instance
- This improves performance and reduces memory usage in development and runtime

## Context
The warning "[Shiki] 10 instances have been created" was appearing due to creating a new highlighter instance for each MDX file processed. While the warning still appears during build (due to Next.js's parallel static generation using multiple worker processes), this change significantly improves performance in development and runtime environments.

## Test plan
- [x] Run `pnpm lint` to ensure code quality
- [x] Run `pnpm build` to verify the build still works
- [ ] Verify syntax highlighting still works correctly on blog posts
- [ ] Check that the warning is reduced/eliminated in development mode

🤖 Generated with [Claude Code](https://claude.ai/code)