### PR TITLE
feat: ブログ記事にタグ表示機能を追加

### DIFF
--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -73,7 +73,11 @@ export default async function Page(props: Props) {
   return (
     <>
       <div className="my-10 pb-8">
-        <PostTitle title={frontmatter.title} date={frontmatter.publishedTime} />
+        <PostTitle
+          title={frontmatter.title}
+          date={frontmatter.publishedTime}
+          tags={frontmatter.tags}
+        />
       </div>
 
       {content}

--- a/components/PostTags.tsx
+++ b/components/PostTags.tsx
@@ -1,0 +1,24 @@
+import type { FC } from 'react';
+
+type Props = {
+  tags: string[] | null | undefined;
+};
+
+export const PostTags: FC<Props> = ({ tags }) => {
+  if (!tags || tags.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2 mt-2">
+      {tags.map((tag) => (
+        <span
+          key={tag}
+          className="inline-block px-3 py-1 text-xs font-medium text-gray-600 border border-gray-300 rounded-lg hover:border-gray-400 hover:bg-gray-50 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+        >
+          {tag}
+        </span>
+      ))}
+    </div>
+  );
+};

--- a/components/PostTitle.tsx
+++ b/components/PostTitle.tsx
@@ -1,14 +1,19 @@
 import type { FC } from 'react';
 import { formatDate } from '../lib/date';
+import { PostTags } from './PostTags';
 
-export const PostTitle: FC<{ title: string; date: string }> = ({
-  title,
-  date,
-}) => {
+type Props = {
+  title: string;
+  date: string;
+  tags?: string[] | null;
+};
+
+export const PostTitle: FC<Props> = ({ title, date, tags }) => {
   return (
     <>
       <h1 className="my-4 text-custom-3xl font-bold">{title}</h1>
       <p>{formatDate(date)} 公開</p>
+      <PostTags tags={tags} />
     </>
   );
 };


### PR DESCRIPTION
## 概要
- ブログ記事にタグを表示する機能を実装しました
- PostTagsコンポーネントを新規作成し、タグをバッジ形式で表示します
- 記事詳細ページの投稿タイトル部分にタグ表示を統合しました

## 変更内容
- `components/PostTags.tsx`: タグ表示用の新規コンポーネント
- `components/PostTitle.tsx`: タグ表示を統合
- `app/posts/[slug]/page.tsx`: PostTitleコンポーネントにタグを渡すように修正

## テスト
- [ ] 開発サーバーでタグがある記事の表示確認
- [ ] タグがない記事でもエラーが発生しないことの確認
- [ ] レスポンシブデザインの確認

🤖 Generated with [Claude Code](https://claude.ai/code)