### PR TITLE
feat: タグページ機能を追加

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -7,7 +7,11 @@ export default function robots(): MetadataRoute.Robots {
       userAgent: '*',
       allow: '/',
     },
-    sitemap: [`${BLOG_URL}/sitemap.xml`, `${BLOG_URL}/posts/sitemap.xml`],
+    sitemap: [
+      `${BLOG_URL}/sitemap.xml`,
+      `${BLOG_URL}/posts/sitemap.xml`,
+      `${BLOG_URL}/tags/sitemap.xml`,
+    ],
     host: BLOG_URL,
   };
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -15,5 +15,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'daily',
       priority: 0.5,
     },
+    {
+      url: `${BLOG_URL}/tags`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.6,
+    },
   ];
 }

--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -1,0 +1,66 @@
+import { PostCard } from '@/components/PostCard';
+import { BLOG_NAME } from '@/lib/constants';
+import { getAllTags, getPostsByTag } from '@/lib/post';
+import type { Metadata } from 'next';
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  const allTags = getAllTags();
+
+  return Array.from(allTags.keys()).map((tag) => ({
+    tag: tag,
+  }));
+}
+
+type Props = {
+  params: Promise<{
+    tag: string;
+  }>;
+};
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const params = await props.params;
+  const tag = decodeURIComponent(params.tag);
+
+  return {
+    title: `${tag} - ${BLOG_NAME}`,
+    description: `${tag}に関する記事一覧`,
+    openGraph: {
+      type: 'website',
+      url: `/tags/${params.tag}`,
+      title: `${tag} - ${BLOG_NAME}`,
+      description: `${tag}に関する記事一覧`,
+      siteName: BLOG_NAME,
+    },
+    twitter: {
+      title: `${tag} - ${BLOG_NAME}`,
+      description: `${tag}に関する記事一覧`,
+    },
+  };
+}
+
+export default async function Page(props: Props) {
+  const params = await props.params;
+  const tag = decodeURIComponent(params.tag);
+  const posts = getPostsByTag(tag);
+
+  return (
+    <div>
+      <h1 className="text-3xl font-bold mb-8">
+        <span className="text-gray-600">#</span>
+        {tag}
+      </h1>
+      <div className="grid gap-3">
+        {posts.map((post) => (
+          <PostCard
+            key={post.slug}
+            slug={post.slug}
+            title={post.title}
+            publishedTime={post.publishedTime}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/tags/page.tsx
+++ b/app/tags/page.tsx
@@ -1,0 +1,48 @@
+import { BLOG_NAME } from '@/lib/constants';
+import { getAllTags } from '@/lib/post';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: `タグ一覧 - ${BLOG_NAME}`,
+  description: 'すべてのタグの一覧',
+  openGraph: {
+    type: 'website',
+    url: '/tags',
+    title: `タグ一覧 - ${BLOG_NAME}`,
+    description: 'すべてのタグの一覧',
+    siteName: BLOG_NAME,
+  },
+  twitter: {
+    title: `タグ一覧 - ${BLOG_NAME}`,
+    description: 'すべてのタグの一覧',
+  },
+};
+
+export default function Page() {
+  const allTags = getAllTags();
+
+  // タグを記事数の降順でソート
+  const sortedTags = Array.from(allTags.entries()).sort((a, b) => b[1] - a[1]);
+
+  return (
+    <div>
+      <h1 className="text-3xl font-bold mb-8">タグ一覧</h1>
+      <div className="grid gap-3">
+        {sortedTags.map(([tag, count]) => (
+          <Link
+            key={tag}
+            href={`/tags/${encodeURIComponent(tag)}`}
+            className="flex items-center justify-between p-4 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
+          >
+            <span className="text-lg">
+              <span className="text-gray-600">#</span>
+              {tag}
+            </span>
+            <span className="text-sm text-gray-500">{count}件の記事</span>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/tags/sitemap.ts
+++ b/app/tags/sitemap.ts
@@ -1,0 +1,29 @@
+import { BLOG_URL } from '@/lib/constants';
+import { getAllTags } from '@/lib/post';
+import type { MetadataRoute } from 'next';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const allTags = getAllTags();
+
+  const sitemapEntries: MetadataRoute.Sitemap = [
+    // タグ一覧ページ
+    {
+      url: `${BLOG_URL}/tags`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.6,
+    },
+  ];
+
+  // 各タグページ
+  for (const [tag] of Array.from(allTags.entries())) {
+    sitemapEntries.push({
+      url: `${BLOG_URL}/tags/${encodeURIComponent(tag)}`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.7,
+    });
+  }
+
+  return sitemapEntries;
+}

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -16,6 +16,15 @@ export const Navigation: FC = () => {
         </div>
         <div>
           <NextLink
+            href="/tags"
+            prefetch={false}
+            className="text-blue-500 hover:underline"
+          >
+            Tags
+          </NextLink>
+        </div>
+        <div>
+          <NextLink
             href="/about"
             prefetch={false}
             className="text-blue-500 hover:underline"

--- a/components/PostTags.tsx
+++ b/components/PostTags.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import type { FC } from 'react';
 
 type Props = {
@@ -12,12 +13,13 @@ export const PostTags: FC<Props> = ({ tags }) => {
   return (
     <div className="flex flex-wrap gap-2 mt-2">
       {tags.map((tag) => (
-        <span
+        <Link
           key={tag}
+          href={`/tags/${encodeURIComponent(tag)}`}
           className="inline-block px-3 py-1 text-xs font-medium text-gray-600 border border-gray-300 rounded-lg hover:border-gray-400 hover:bg-gray-50 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
         >
-          {tag}
-        </span>
+          #{tag}
+        </Link>
       ))}
     </div>
   );

--- a/lib/post.ts
+++ b/lib/post.ts
@@ -81,3 +81,36 @@ export function getRelatedPosts(
 
   return relatedPosts;
 }
+
+/**
+ * すべての投稿から一意なタグとその投稿数を取得する
+ * @returns タグとその投稿数のマップ
+ */
+export function getAllTags(): Map<string, number> {
+  const allPosts = getAllPosts();
+  const tagCounts = new Map<string, number>();
+
+  for (const post of allPosts) {
+    if (post.tags && post.tags.length > 0) {
+      for (const tag of post.tags) {
+        tagCounts.set(tag, (tagCounts.get(tag) || 0) + 1);
+      }
+    }
+  }
+
+  return tagCounts;
+}
+
+/**
+ * 指定されたタグを持つ投稿を取得する
+ * @param tag - 検索対象のタグ
+ * @returns タグを持つ投稿の配列
+ */
+export function getPostsByTag(tag: string): PostData[] {
+  const allPosts = getAllPosts();
+
+  return allPosts.filter((post) => {
+    if (!post.tags || post.tags.length === 0) return false;
+    return post.tags.includes(tag);
+  });
+}


### PR DESCRIPTION
## Summary
- タグ一覧ページ (/tags) を実装し、記事数の降順でタグを表示
- 個別タグページ (/tags/[tag]) を実装し、該当するタグの記事一覧を表示
- SEO対応としてタグ用のsitemap.xmlを追加
- Navigationコンポーネントにタグページへのリンクを追加
- PostTagsコンポーネントをクリック可能なリンクに変更

## Test plan
- [ ] タグ一覧ページが正しく表示される
- [ ] 個別タグページが正しく表示される
- [ ] SEOメタデータが適切に設定される
- [ ] サイトマップにタグページが含まれる
- [ ] ナビゲーションからタグページにアクセスできる

🤖 Generated with [Claude Code](https://claude.ai/code)