### PR TITLE
feat: MCPサポートとPlaywright連携を追加

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,3 +34,15 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           timeout_minutes: "60"
+          allowed_tools: |
+            Bash(pnpm:*)
+            Bash(gh pr:*)
+            WebSearch
+            WebFetch
+            mcp__playwright__browser_navigate
+            mcp__playwright__browser_wait_for
+            mcp__playwright__browser_click
+            mcp__playwright__browser_close
+            mcp__playwright__browser_take_screenshot
+            mcp__playwright__browser_press_key
+            mcp__playwright__browser_console_messages

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@latest"]
+    }
+  }
+}


### PR DESCRIPTION
## 概要
Claude Code ActionsにMCP（Model Context Protocol）サポートを追加し、Playwright連携を可能にしました。

## 変更内容
- **Claude Code Actionsワークフロー**: 許可されたツールのリストを追加
  - pnpmコマンド、GitHub PR操作、Web検索・取得
  - Playwrightブラウザ操作ツール
- **MCP設定ファイル**: `.mcp.json`を追加してPlaywrightサーバーを設定

## テスト計画
- [ ] Claude Code ActionsでPlaywrightツールが正常に使用できることを確認
- [ ] 既存のワークフローが影響を受けていないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)