### PR TITLE
build: add @tailwindcss/oxide to onlyBuiltDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
+      "@tailwindcss/oxide",
       "sharp",
       "workerd"
     ]


### PR DESCRIPTION
## Summary
- Add @tailwindcss/oxide to pnpm onlyBuiltDependencies to ensure proper native dependency handling

## Test plan
- [ ] Build process should work correctly with the native dependency configuration
- [ ] Verify that @tailwindcss/oxide builds properly during pnpm install

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `@tailwindcss/oxide` to `pnpm.onlyBuiltDependencies` in `package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3d096b11dd6c74c112e7c154d54391ed5847427. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->