### PR TITLE
Implement @graph-based JSON-LD with BreadcrumbList support

### DIFF
--- a/docs/adr/2026-04-11-improve-structured-data.md
+++ b/docs/adr/2026-04-11-improve-structured-data.md
@@ -1,0 +1,71 @@
+# Improve Structured Data (JSON-LD) with @graph Pattern and BreadcrumbList
+
+## Status
+
+accepted
+
+## Context
+
+サイト全体で JSON-LD 構造化データを実装済みだが、以下の課題がある:
+
+1. **@id によるエンティティリンクがない**: 各ページが孤立した JSON-LD ブロックを持ち、エンティティ間の参照関係が表現されていない
+2. **@graph パターン未使用**: ページごとに単一エンティティのみ出力しており、WebSite/Person/WebPage/BreadcrumbList などの関連エンティティをグラフとして表現できていない
+3. **BreadcrumbList 未実装**: Google 検索結果でのパンくず表示に必要な構造化データが全ページで欠落
+4. **WebPage ラッパー未使用**: Google が推奨するエンティティスタック（WebSite → WebPage → BlogPosting）の中間層がない
+5. **Person エンティティの不整合**: ページごとに異なるプロパティセットで author/Person を定義しており、一貫性がない
+6. **inLanguage 未指定**: コンテンツ言語がJSON-LDに明示されていない
+
+これらの改善により、Google Rich Results への適格性向上（特にパンくず表示）、AI 検索（Google AI Overviews 等）での引用可能性の向上、エンティティグラフの一貫性確保が期待できる。
+
+## Decision
+
+### @graph + @id パターンの採用
+
+各ページの JSON-LD を単一エンティティから `@graph` 配列に移行する。すべてのエンティティに `@id`（canonical URL + fragment）を付与し、ページ間で一貫した参照を可能にする。
+
+#### @id 規約
+
+| エンティティ | @id パターン |
+|---|---|
+| WebSite | `https://thinceller.net/#website` |
+| Person | `https://thinceller.net/#person` |
+| WebPage | `https://thinceller.net{path}#webpage` |
+| BlogPosting | `https://thinceller.net/blog/{slug}#blogposting` |
+| BreadcrumbList | `https://thinceller.net{path}#breadcrumb` |
+
+#### ページごとのエンティティ構成
+
+| ページ | エンティティ |
+|---|---|
+| `/` | WebSite, Person, WebPage |
+| `/about` | WebSite, Person, ProfilePage, BreadcrumbList |
+| `/blog` | WebSite, Person, CollectionPage, BreadcrumbList |
+| `/blog/[slug]` | WebSite, Person, WebPage, BlogPosting, BreadcrumbList |
+| `/blog/tags` | WebSite, Person, CollectionPage, BreadcrumbList |
+| `/blog/tags/[tag]` | WebSite, Person, CollectionPage, BreadcrumbList |
+
+### 実装方針
+
+- `src/lib/structured-data.ts` に再利用可能なエンティティ生成ヘルパーを集約
+- `src/components/JsonLd.tsx` を `schema-dts` の `Graph` 型に対応させる
+- 既存の `schema-dts` ライブラリを継続使用し、TypeScript の型安全性を維持
+
+### Considered Options
+
+1. **複数 `<script>` ブロック**: エンティティごとに別々の `<script type="application/ld+json">` を出力する方法。@id による相互参照は可能だが、`@graph` の方がクリーンで、Google のドキュメントでも推奨されている。却下。
+
+2. **`next-seo` 等の外部ライブラリ**: 構造化データ生成を外部ライブラリに委譲する方法。追加の依存関係が発生し、`schema-dts` で既に十分な型安全性が確保されている。却下。
+
+## Consequences
+
+### Positive
+
+- Google Rich Results のパンくず表示が有効になる
+- エンティティグラフの一貫性により、検索エンジンとLLMがサイト構造をより正確に理解できる
+- ヘルパーモジュールにより、新しいページ追加時の構造化データ実装が容易になる
+- `schema-dts` の型チェックにより、構造化データの正確性がコンパイル時に検証される
+
+### Negative
+
+- 各ページの JSON-LD 構築がやや複雑になる（ヘルパーで軽減）
+- WebSite/Person エンティティが全ページで重複するが、Google は各ページを独立に処理するため必要

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -112,11 +112,13 @@ test.describe('構造化データ（JSON-LD）', () => {
     const website = data['@graph'].find(
       (e: { '@type': string }) => e['@type'] === 'WebSite',
     );
+    expect(website).toBeDefined();
     expect(website['@id']).toContain('#website');
 
     const person = data['@graph'].find(
       (e: { '@type': string }) => e['@type'] === 'Person',
     );
+    expect(person).toBeDefined();
     expect(person['@id']).toContain('#person');
   });
 
@@ -209,6 +211,7 @@ test.describe('構造化データ（JSON-LD）', () => {
     const breadcrumb = data['@graph'].find(
       (e: { '@type': string }) => e['@type'] === 'BreadcrumbList',
     );
+    expect(breadcrumb).toBeDefined();
     expect(breadcrumb.itemListElement).toHaveLength(2);
   });
 });

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -80,6 +80,134 @@ test.describe('RSSフィード検証', () => {
   });
 });
 
+// biome-ignore lint/suspicious/noExplicitAny: JSON-LD parsing in tests
+type JsonLdGraph = { '@context': string; '@graph': any[] };
+
+function parseJsonLd(text: string | null): JsonLdGraph {
+  if (text === null) {
+    throw new Error('JSON-LD script not found');
+  }
+  return JSON.parse(text) as JsonLdGraph;
+}
+
+test.describe('構造化データ（JSON-LD）', () => {
+  test('トップページに WebSite, Person, WebPage が含まれる', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    const text = await page
+      .locator('script[type="application/ld+json"]')
+      .textContent();
+    const data = parseJsonLd(text);
+
+    expect(data['@context']).toBe('https://schema.org');
+    expect(data['@graph']).toBeDefined();
+
+    const types = data['@graph'].map((e: { '@type': string }) => e['@type']);
+    expect(types).toContain('WebSite');
+    expect(types).toContain('Person');
+    expect(types).toContain('WebPage');
+
+    // @id が設定されていること
+    const website = data['@graph'].find(
+      (e: { '@type': string }) => e['@type'] === 'WebSite',
+    );
+    expect(website['@id']).toContain('#website');
+
+    const person = data['@graph'].find(
+      (e: { '@type': string }) => e['@type'] === 'Person',
+    );
+    expect(person['@id']).toContain('#person');
+  });
+
+  test('トップページに BreadcrumbList が含まれない', async ({ page }) => {
+    await page.goto('/');
+    const text = await page
+      .locator('script[type="application/ld+json"]')
+      .textContent();
+    const data = parseJsonLd(text);
+
+    const types = data['@graph'].map((e: { '@type': string }) => e['@type']);
+    expect(types).not.toContain('BreadcrumbList');
+  });
+
+  test('記事ページに BlogPosting, BreadcrumbList, WebPage が含まれる', async ({
+    page,
+  }) => {
+    await page.goto(`/blog/${latestPostSlug}`);
+    const text = await page
+      .locator('script[type="application/ld+json"]')
+      .textContent();
+    const data = parseJsonLd(text);
+
+    const types = data['@graph'].map((e: { '@type': string }) => e['@type']);
+    expect(types).toContain('BlogPosting');
+    expect(types).toContain('BreadcrumbList');
+    expect(types).toContain('WebPage');
+    expect(types).toContain('WebSite');
+    expect(types).toContain('Person');
+
+    // BlogPosting の author が Person の @id を参照していること
+    const blogPosting = data['@graph'].find(
+      (e: { '@type': string }) => e['@type'] === 'BlogPosting',
+    );
+    const person = data['@graph'].find(
+      (e: { '@type': string }) => e['@type'] === 'Person',
+    );
+    expect(blogPosting.author['@id']).toBe(person['@id']);
+
+    // BreadcrumbList に3つのアイテムがあること (Home > Blog > Post)
+    const breadcrumb = data['@graph'].find(
+      (e: { '@type': string }) => e['@type'] === 'BreadcrumbList',
+    );
+    expect(breadcrumb.itemListElement).toHaveLength(3);
+  });
+
+  test('Aboutページに ProfilePage と BreadcrumbList が含まれる', async ({
+    page,
+  }) => {
+    await page.goto('/about');
+    const text = await page
+      .locator('script[type="application/ld+json"]')
+      .textContent();
+    const data = parseJsonLd(text);
+
+    const types = data['@graph'].map((e: { '@type': string }) => e['@type']);
+    expect(types).toContain('ProfilePage');
+    expect(types).toContain('BreadcrumbList');
+    expect(types).toContain('Person');
+
+    // ProfilePage の mainEntity が Person を参照していること
+    const profilePage = data['@graph'].find(
+      (e: { '@type': string }) => e['@type'] === 'ProfilePage',
+    );
+    const person = data['@graph'].find(
+      (e: { '@type': string }) => e['@type'] === 'Person',
+    );
+    expect(profilePage.mainEntity['@id']).toBe(person['@id']);
+  });
+
+  test('ブログ一覧ページに CollectionPage と BreadcrumbList が含まれる', async ({
+    page,
+  }) => {
+    await page.goto('/blog');
+    const text = await page
+      .locator('script[type="application/ld+json"]')
+      .textContent();
+    const data = parseJsonLd(text);
+
+    const types = data['@graph'].map((e: { '@type': string }) => e['@type']);
+    expect(types).toContain('CollectionPage');
+    expect(types).toContain('BreadcrumbList');
+
+    // BreadcrumbList に2つのアイテムがあること (Home > Blog)
+    const breadcrumb = data['@graph'].find(
+      (e: { '@type': string }) => e['@type'] === 'BreadcrumbList',
+    );
+    expect(breadcrumb.itemListElement).toHaveLength(2);
+  });
+});
+
 test.describe('ナビゲーション', () => {
   test('トップ → ブログ一覧 → 記事詳細 の遷移が正常に動作する', async ({
     page,

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -154,12 +154,15 @@ test.describe('構造化データ（JSON-LD）', () => {
     const person = data['@graph'].find(
       (e: { '@type': string }) => e['@type'] === 'Person',
     );
+    expect(blogPosting).toBeDefined();
+    expect(person).toBeDefined();
     expect(blogPosting.author['@id']).toBe(person['@id']);
 
     // BreadcrumbList に3つのアイテムがあること (Home > Blog > Post)
     const breadcrumb = data['@graph'].find(
       (e: { '@type': string }) => e['@type'] === 'BreadcrumbList',
     );
+    expect(breadcrumb).toBeDefined();
     expect(breadcrumb.itemListElement).toHaveLength(3);
   });
 
@@ -184,6 +187,8 @@ test.describe('構造化データ（JSON-LD）', () => {
     const person = data['@graph'].find(
       (e: { '@type': string }) => e['@type'] === 'Person',
     );
+    expect(profilePage).toBeDefined();
+    expect(person).toBeDefined();
     expect(profilePage.mainEntity['@id']).toBe(person['@id']);
   });
 

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import Image from 'next/image';
 
 import { JsonLd } from '@/components/JsonLd';
+import { BLOG_URL } from '@/lib/constants';
 import {
   createBreadcrumbList,
   createGraphJsonLd,
@@ -24,8 +25,8 @@ const jsonLd = createGraphJsonLd([
     description: 'thincellerについて',
   }),
   createBreadcrumbList('/about', [
-    { name: 'Home', url: 'https://thinceller.net' },
-    { name: 'About', url: 'https://thinceller.net/about' },
+    { name: 'Home', url: BLOG_URL },
+    { name: 'About', url: `${BLOG_URL}/about` },
   ]),
 ]);
 

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,33 +1,33 @@
 import type { Metadata } from 'next';
 import Image from 'next/image';
-import type { ProfilePage, WithContext } from 'schema-dts';
 
 import { JsonLd } from '@/components/JsonLd';
 import {
-  AUTHOR_GITHUB,
-  AUTHOR_TWITTER,
-  AVATAR_URL,
-  BLOG_AUTHOR,
-  BLOG_AUTHOR_FULL_NAME,
-} from '@/lib/constants';
+  createBreadcrumbList,
+  createGraphJsonLd,
+  createPersonEntity,
+  createProfilePageEntity,
+  createWebSiteEntity,
+} from '@/lib/structured-data';
 import AvatarImage from '../../../public/images/avatar.jpg';
 
 export const metadata: Metadata = {
   title: 'About',
 };
 
-const jsonLd: WithContext<ProfilePage> = {
-  '@context': 'https://schema.org',
-  '@type': 'ProfilePage',
-  mainEntity: {
-    '@type': 'Person',
-    name: BLOG_AUTHOR,
-    alternateName: BLOG_AUTHOR_FULL_NAME,
-    description: 'ソフトウェアエンジニア',
-    image: AVATAR_URL,
-    sameAs: [AUTHOR_TWITTER, AUTHOR_GITHUB],
-  },
-};
+const jsonLd = createGraphJsonLd([
+  createWebSiteEntity(),
+  createPersonEntity(),
+  createProfilePageEntity({
+    path: '/about',
+    name: 'About',
+    description: 'thincellerについて',
+  }),
+  createBreadcrumbList('/about', [
+    { name: 'Home', url: 'https://thinceller.net' },
+    { name: 'About', url: 'https://thinceller.net/about' },
+  ]),
+]);
 
 export default function Page() {
   return (

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,14 +1,21 @@
 import type { Metadata } from 'next';
-import type { BlogPosting, WithContext } from 'schema-dts';
 
 import { JsonLd } from '@/components/JsonLd';
 import { PostFooter } from '@/components/PostFooter';
 import { PostTitle } from '@/components/PostTitle';
 import { RelatedPosts } from '@/components/RelatedPosts';
 import { TableOfContents } from '@/components/TableOfContents';
-import { AVATAR_URL, BLOG_AUTHOR, BLOG_URL, SITE_NAME } from '@/lib/constants';
+import { BLOG_AUTHOR, BLOG_URL, SITE_NAME } from '@/lib/constants';
 import { getPostBySlug } from '@/lib/mdx';
 import { getAllPosts, getRelatedPosts } from '@/lib/post';
+import {
+  createBlogPostingEntity,
+  createBreadcrumbList,
+  createGraphJsonLd,
+  createPersonEntity,
+  createWebPageEntity,
+  createWebSiteEntity,
+} from '@/lib/structured-data';
 
 export const dynamicParams = false;
 
@@ -58,30 +65,33 @@ export default async function Page(props: Props) {
   // 関連記事を取得
   const relatedPosts = getRelatedPosts(frontmatter.tags || [], params.slug);
 
-  const jsonLd: WithContext<BlogPosting> = {
-    '@context': 'https://schema.org',
-    '@type': 'BlogPosting',
-    headline: frontmatter.title,
-    description: frontmatter.description,
-    datePublished: frontmatter.publishedTime,
-    dateModified: frontmatter.modifiedTime ?? frontmatter.publishedTime,
-    author: {
-      '@type': 'Person',
-      name: BLOG_AUTHOR,
-      url: `${BLOG_URL}/about`,
-    },
-    publisher: {
-      '@type': 'Organization',
-      name: SITE_NAME,
-      logo: {
-        '@type': 'ImageObject',
-        url: AVATAR_URL,
+  const postPath = `/blog/${params.slug}`;
+  const jsonLd = createGraphJsonLd([
+    createWebSiteEntity(),
+    createPersonEntity(),
+    createWebPageEntity({
+      path: postPath,
+      name: frontmatter.title,
+      description: frontmatter.description,
+    }),
+    createBlogPostingEntity({
+      slug: params.slug,
+      title: frontmatter.title,
+      description: frontmatter.description,
+      publishedTime: frontmatter.publishedTime,
+      modifiedTime: frontmatter.modifiedTime,
+      tags: frontmatter.tags,
+      imageUrl: `${BLOG_URL}${postPath}/opengraph-image`,
+    }),
+    createBreadcrumbList(postPath, [
+      { name: 'Home', url: BLOG_URL },
+      { name: 'Blog', url: `${BLOG_URL}/blog` },
+      {
+        name: frontmatter.title,
+        url: `${BLOG_URL}${postPath}`,
       },
-    },
-    image: `${BLOG_URL}/blog/${params.slug}/opengraph-image`,
-    url: `${BLOG_URL}/blog/${params.slug}`,
-    keywords: frontmatter.tags?.join(', '),
-  };
+    ]),
+  ]);
 
   return (
     <>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from 'next';
-import type { CollectionPage, WithContext } from 'schema-dts';
 
 import { JsonLd } from '@/components/JsonLd';
 import { PostCard } from '@/components/PostCard';
-import { BLOG_NAME, BLOG_URL } from '@/lib/constants';
+import { BLOG_NAME } from '@/lib/constants';
 import { getAllPosts } from '@/lib/post';
+import {
+  createBreadcrumbList,
+  createCollectionPageEntity,
+  createGraphJsonLd,
+  createPersonEntity,
+  createWebSiteEntity,
+} from '@/lib/structured-data';
 
 export const metadata: Metadata = {
   title: {
@@ -13,13 +19,19 @@ export const metadata: Metadata = {
   description: 'ソフトウェアエンジニアthincellerのブログ記事一覧です',
 };
 
-const jsonLd: WithContext<CollectionPage> = {
-  '@context': 'https://schema.org',
-  '@type': 'CollectionPage',
-  name: BLOG_NAME,
-  description: 'ソフトウェアエンジニアthincellerのブログ記事一覧です',
-  url: `${BLOG_URL}/blog`,
-};
+const jsonLd = createGraphJsonLd([
+  createWebSiteEntity(),
+  createPersonEntity(),
+  createCollectionPageEntity({
+    path: '/blog',
+    name: BLOG_NAME,
+    description: 'ソフトウェアエンジニアthincellerのブログ記事一覧です',
+  }),
+  createBreadcrumbList('/blog', [
+    { name: 'Home', url: 'https://thinceller.net' },
+    { name: 'Blog', url: 'https://thinceller.net/blog' },
+  ]),
+]);
 
 export default function Page() {
   const allPosts = getAllPosts();

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 
 import { JsonLd } from '@/components/JsonLd';
 import { PostCard } from '@/components/PostCard';
-import { BLOG_NAME } from '@/lib/constants';
+import { BLOG_NAME, BLOG_URL } from '@/lib/constants';
 import { getAllPosts } from '@/lib/post';
 import {
   createBreadcrumbList,
@@ -28,8 +28,8 @@ const jsonLd = createGraphJsonLd([
     description: 'ソフトウェアエンジニアthincellerのブログ記事一覧です',
   }),
   createBreadcrumbList('/blog', [
-    { name: 'Home', url: 'https://thinceller.net' },
-    { name: 'Blog', url: 'https://thinceller.net/blog' },
+    { name: 'Home', url: BLOG_URL },
+    { name: 'Blog', url: `${BLOG_URL}/blog` },
   ]),
 ]);
 

--- a/src/app/blog/tags/[tag]/page.tsx
+++ b/src/app/blog/tags/[tag]/page.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from 'next';
-import type { CollectionPage, WithContext } from 'schema-dts';
 
 import { JsonLd } from '@/components/JsonLd';
 import { PostCard } from '@/components/PostCard';
 import { BLOG_NAME, BLOG_URL } from '@/lib/constants';
 import { getAllTags, getPostsByTag } from '@/lib/post';
+import {
+  createBreadcrumbList,
+  createCollectionPageEntity,
+  createGraphJsonLd,
+  createPersonEntity,
+  createWebSiteEntity,
+} from '@/lib/structured-data';
 
 export const dynamicParams = false;
 
@@ -48,17 +54,31 @@ export default async function Page(props: Props) {
   const tag = decodeURIComponent(params.tag);
   const posts = getPostsByTag(tag);
 
-  const jsonLd: WithContext<CollectionPage> = {
-    '@context': 'https://schema.org',
-    '@type': 'CollectionPage',
-    name: `${tag} | ${BLOG_NAME}`,
-    description: `${tag}に関する記事一覧`,
-    url: `${BLOG_URL}/blog/tags/${params.tag}`,
-    about: {
-      '@type': 'Thing',
-      name: tag,
+  const tagPath = `/blog/tags/${params.tag}`;
+  const jsonLd = createGraphJsonLd([
+    createWebSiteEntity(),
+    createPersonEntity(),
+    {
+      ...createCollectionPageEntity({
+        path: tagPath,
+        name: `${tag} | ${BLOG_NAME}`,
+        description: `${tag}に関する記事一覧`,
+      }),
+      about: {
+        '@type': 'Thing' as const,
+        name: tag,
+      },
     },
-  };
+    createBreadcrumbList(tagPath, [
+      { name: 'Home', url: BLOG_URL },
+      { name: 'Blog', url: `${BLOG_URL}/blog` },
+      {
+        name: 'タグ一覧',
+        url: `${BLOG_URL}/blog/tags`,
+      },
+      { name: tag, url: `${BLOG_URL}${tagPath}` },
+    ]),
+  ]);
 
   return (
     <>

--- a/src/app/blog/tags/page.tsx
+++ b/src/app/blog/tags/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 
 import { JsonLd } from '@/components/JsonLd';
-import { BLOG_NAME } from '@/lib/constants';
+import { BLOG_NAME, BLOG_URL } from '@/lib/constants';
 import { getAllTags } from '@/lib/post';
 import {
   createBreadcrumbList,
@@ -37,11 +37,11 @@ const jsonLd = createGraphJsonLd([
     description: 'すべてのタグの一覧',
   }),
   createBreadcrumbList('/blog/tags', [
-    { name: 'Home', url: 'https://thinceller.net' },
-    { name: 'Blog', url: 'https://thinceller.net/blog' },
+    { name: 'Home', url: BLOG_URL },
+    { name: 'Blog', url: `${BLOG_URL}/blog` },
     {
       name: 'タグ一覧',
-      url: 'https://thinceller.net/blog/tags',
+      url: `${BLOG_URL}/blog/tags`,
     },
   ]),
 ]);

--- a/src/app/blog/tags/page.tsx
+++ b/src/app/blog/tags/page.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import type { CollectionPage, WithContext } from 'schema-dts';
 
 import { JsonLd } from '@/components/JsonLd';
-import { BLOG_NAME, BLOG_URL } from '@/lib/constants';
+import { BLOG_NAME } from '@/lib/constants';
 import { getAllTags } from '@/lib/post';
+import {
+  createBreadcrumbList,
+  createCollectionPageEntity,
+  createGraphJsonLd,
+  createPersonEntity,
+  createWebSiteEntity,
+} from '@/lib/structured-data';
 
 export const metadata: Metadata = {
   title: 'タグ一覧',
@@ -22,13 +28,23 @@ export const metadata: Metadata = {
   },
 };
 
-const jsonLd: WithContext<CollectionPage> = {
-  '@context': 'https://schema.org',
-  '@type': 'CollectionPage',
-  name: 'タグ一覧',
-  description: 'すべてのタグの一覧',
-  url: `${BLOG_URL}/blog/tags`,
-};
+const jsonLd = createGraphJsonLd([
+  createWebSiteEntity(),
+  createPersonEntity(),
+  createCollectionPageEntity({
+    path: '/blog/tags',
+    name: 'タグ一覧',
+    description: 'すべてのタグの一覧',
+  }),
+  createBreadcrumbList('/blog/tags', [
+    { name: 'Home', url: 'https://thinceller.net' },
+    { name: 'Blog', url: 'https://thinceller.net/blog' },
+    {
+      name: 'タグ一覧',
+      url: 'https://thinceller.net/blog/tags',
+    },
+  ]),
+]);
 
 export default function Page() {
   const allTags = getAllTags();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,18 +1,18 @@
 import type { Metadata } from 'next';
 import Image from 'next/image';
-import type { WebSite, WithContext } from 'schema-dts';
 
 import { JsonLd } from '@/components/JsonLd';
 import { PostCard } from '@/components/PostCard';
 import { SectionHeading } from '@/components/SectionHeading';
 import { ZennArticleCard } from '@/components/ZennArticleCard';
-import {
-  BLOG_AUTHOR,
-  BLOG_URL,
-  SITE_NAME,
-  ZENN_PROFILE_URL,
-} from '@/lib/constants';
+import { SITE_NAME, ZENN_PROFILE_URL } from '@/lib/constants';
 import { getAllPosts } from '@/lib/post';
+import {
+  createGraphJsonLd,
+  createPersonEntity,
+  createWebPageEntity,
+  createWebSiteEntity,
+} from '@/lib/structured-data';
 import { getLatestZennArticles } from '@/lib/zenn';
 import AvatarImage from '../../public/images/avatar.jpg';
 
@@ -25,17 +25,18 @@ export default async function Page() {
   const recentPosts = getAllPosts().slice(0, 5);
   const zennArticles = await getLatestZennArticles(5);
 
-  const jsonLd: WithContext<WebSite> = {
-    '@context': 'https://schema.org',
-    '@type': 'WebSite',
-    name: SITE_NAME,
-    url: BLOG_URL,
-    description: 'ソフトウェアエンジニアthincellerの個人サイトです',
-    author: {
-      '@type': 'Person',
-      name: BLOG_AUTHOR,
+  const jsonLd = createGraphJsonLd([
+    createWebSiteEntity(),
+    createPersonEntity(),
+    {
+      ...createWebPageEntity({
+        path: '',
+        name: SITE_NAME,
+        description: 'ソフトウェアエンジニアthincellerの個人サイトです',
+      }),
+      about: { '@id': 'https://thinceller.net/#person' },
     },
-  };
+  ]);
 
   return (
     <>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ import { JsonLd } from '@/components/JsonLd';
 import { PostCard } from '@/components/PostCard';
 import { SectionHeading } from '@/components/SectionHeading';
 import { ZennArticleCard } from '@/components/ZennArticleCard';
-import { SITE_NAME, ZENN_PROFILE_URL } from '@/lib/constants';
+import { BLOG_URL, SITE_NAME, ZENN_PROFILE_URL } from '@/lib/constants';
 import { getAllPosts } from '@/lib/post';
 import {
   createGraphJsonLd,
@@ -34,7 +34,7 @@ export default async function Page() {
         name: SITE_NAME,
         description: 'ソフトウェアエンジニアthincellerの個人サイトです',
       }),
-      about: { '@id': 'https://thinceller.net/#person' },
+      about: { '@id': `${BLOG_URL}/#person` },
     },
   ]);
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,6 +33,7 @@ export default async function Page() {
         path: '',
         name: SITE_NAME,
         description: 'ソフトウェアエンジニアthincellerの個人サイトです',
+        hasBreadcrumb: false,
       }),
       about: { '@id': `${BLOG_URL}/#person` },
     },

--- a/src/components/JsonLd.tsx
+++ b/src/components/JsonLd.tsx
@@ -1,10 +1,10 @@
-import type { Thing, WithContext } from 'schema-dts';
+import type { Graph, Thing, WithContext } from 'schema-dts';
 
-type JsonLdProps<T extends Thing> = {
-  data: WithContext<T>;
+type JsonLdProps = {
+  data: WithContext<Thing> | Graph;
 };
 
-export function JsonLd<T extends Thing>({ data }: JsonLdProps<T>) {
+export function JsonLd({ data }: JsonLdProps) {
   return (
     <script
       type="application/ld+json"

--- a/src/components/JsonLd.tsx
+++ b/src/components/JsonLd.tsx
@@ -9,7 +9,12 @@ export function JsonLd({ data }: JsonLdProps) {
     <script
       type="application/ld+json"
       // biome-ignore lint/security/noDangerouslySetInnerHtml: Next.js recommended pattern for JSON-LD
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(data)
+          .replace(/</g, '\\u003c')
+          .replace(/>/g, '\\u003e')
+          .replace(/&/g, '\\u0026'),
+      }}
     />
   );
 }

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -50,6 +50,7 @@ type WebPageOptions = {
   path: string;
   name: string;
   description: string;
+  hasBreadcrumb?: boolean;
 };
 
 export function createWebPageEntity(options: WebPageOptions): WebPage {
@@ -62,7 +63,9 @@ export function createWebPageEntity(options: WebPageOptions): WebPage {
     url,
     isPartOf: { '@id': `${BLOG_URL}/#website` },
     inLanguage: 'ja',
-    breadcrumb: { '@id': `${url}#breadcrumb` },
+    ...(options.hasBreadcrumb !== false
+      ? { breadcrumb: { '@id': `${url}#breadcrumb` } }
+      : {}),
   };
 }
 

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -81,7 +81,9 @@ export function createCollectionPageEntity(
     url,
     isPartOf: { '@id': `${BLOG_URL}/#website` },
     inLanguage: 'ja',
-    breadcrumb: { '@id': `${url}#breadcrumb` },
+    ...(options.hasBreadcrumb !== false
+      ? { breadcrumb: { '@id': `${url}#breadcrumb` } }
+      : {}),
   };
 }
 
@@ -96,7 +98,9 @@ export function createProfilePageEntity(options: WebPageOptions): ProfilePage {
     isPartOf: { '@id': `${BLOG_URL}/#website` },
     inLanguage: 'ja',
     mainEntity: { '@id': `${BLOG_URL}/#person` },
-    breadcrumb: { '@id': `${url}#breadcrumb` },
+    ...(options.hasBreadcrumb !== false
+      ? { breadcrumb: { '@id': `${url}#breadcrumb` } }
+      : {}),
   };
 }
 
@@ -148,7 +152,7 @@ export function createBlogPostingEntity(
     publisher: { '@id': `${BLOG_URL}/#person` },
     image: options.imageUrl,
     url,
-    keywords: options.tags?.join(', '),
+    keywords: options.tags?.length ? options.tags.join(', ') : undefined,
     mainEntityOfPage: { '@id': `${url}#webpage` },
     isPartOf: { '@id': `${BLOG_URL}/#website` },
     inLanguage: 'ja',

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -1,0 +1,160 @@
+import type {
+  BlogPosting,
+  BreadcrumbList,
+  CollectionPage,
+  Graph,
+  ListItem,
+  Person,
+  ProfilePage,
+  Thing,
+  WebPage,
+  WebSite,
+} from 'schema-dts';
+
+import {
+  AUTHOR_GITHUB,
+  AUTHOR_TWITTER,
+  AVATAR_URL,
+  BLOG_AUTHOR,
+  BLOG_AUTHOR_FULL_NAME,
+  BLOG_URL,
+  SITE_NAME,
+} from './constants';
+
+export function createWebSiteEntity(): WebSite {
+  return {
+    '@type': 'WebSite',
+    '@id': `${BLOG_URL}/#website`,
+    name: SITE_NAME,
+    url: BLOG_URL,
+    description: 'ソフトウェアエンジニアthincellerの個人サイトです',
+    inLanguage: 'ja',
+    publisher: { '@id': `${BLOG_URL}/#person` },
+  };
+}
+
+export function createPersonEntity(): Person {
+  return {
+    '@type': 'Person',
+    '@id': `${BLOG_URL}/#person`,
+    name: BLOG_AUTHOR,
+    alternateName: BLOG_AUTHOR_FULL_NAME,
+    url: `${BLOG_URL}/about`,
+    image: AVATAR_URL,
+    sameAs: [AUTHOR_TWITTER, AUTHOR_GITHUB],
+    description: 'ソフトウェアエンジニア',
+  };
+}
+
+type WebPageOptions = {
+  path: string;
+  name: string;
+  description: string;
+};
+
+export function createWebPageEntity(options: WebPageOptions): WebPage {
+  const url = `${BLOG_URL}${options.path}`;
+  return {
+    '@type': 'WebPage',
+    '@id': `${url}#webpage`,
+    name: options.name,
+    description: options.description,
+    url,
+    isPartOf: { '@id': `${BLOG_URL}/#website` },
+    inLanguage: 'ja',
+    breadcrumb: { '@id': `${url}#breadcrumb` },
+  };
+}
+
+export function createCollectionPageEntity(
+  options: WebPageOptions,
+): CollectionPage {
+  const url = `${BLOG_URL}${options.path}`;
+  return {
+    '@type': 'CollectionPage',
+    '@id': `${url}#webpage`,
+    name: options.name,
+    description: options.description,
+    url,
+    isPartOf: { '@id': `${BLOG_URL}/#website` },
+    inLanguage: 'ja',
+    breadcrumb: { '@id': `${url}#breadcrumb` },
+  };
+}
+
+export function createProfilePageEntity(options: WebPageOptions): ProfilePage {
+  const url = `${BLOG_URL}${options.path}`;
+  return {
+    '@type': 'ProfilePage',
+    '@id': `${url}#webpage`,
+    name: options.name,
+    description: options.description,
+    url,
+    isPartOf: { '@id': `${BLOG_URL}/#website` },
+    inLanguage: 'ja',
+    mainEntity: { '@id': `${BLOG_URL}/#person` },
+    breadcrumb: { '@id': `${url}#breadcrumb` },
+  };
+}
+
+type BreadcrumbItem = {
+  name: string;
+  url: string;
+};
+
+export function createBreadcrumbList(
+  path: string,
+  items: BreadcrumbItem[],
+): BreadcrumbList {
+  return {
+    '@type': 'BreadcrumbList',
+    '@id': `${BLOG_URL}${path}#breadcrumb`,
+    itemListElement: items.map(
+      (item, index): ListItem => ({
+        '@type': 'ListItem',
+        position: index + 1,
+        name: item.name,
+        item: item.url,
+      }),
+    ),
+  };
+}
+
+type BlogPostingOptions = {
+  slug: string;
+  title: string;
+  description: string;
+  publishedTime: string;
+  modifiedTime?: string;
+  tags?: string[] | null;
+  imageUrl: string;
+};
+
+export function createBlogPostingEntity(
+  options: BlogPostingOptions,
+): BlogPosting {
+  const url = `${BLOG_URL}/blog/${options.slug}`;
+  return {
+    '@type': 'BlogPosting',
+    '@id': `${url}#blogposting`,
+    headline: options.title,
+    description: options.description,
+    datePublished: options.publishedTime,
+    dateModified: options.modifiedTime ?? options.publishedTime,
+    author: { '@id': `${BLOG_URL}/#person` },
+    publisher: { '@id': `${BLOG_URL}/#person` },
+    image: options.imageUrl,
+    url,
+    keywords: options.tags?.join(', '),
+    mainEntityOfPage: { '@id': `${url}#webpage` },
+    isPartOf: { '@id': `${BLOG_URL}/#website` },
+    inLanguage: 'ja',
+  };
+}
+
+export function createGraphJsonLd(entities: Thing[]): Graph {
+  return {
+    '@context': 'https://schema.org',
+    '@graph': entities,
+  };
+}


### PR DESCRIPTION
## Summary

Refactored structured data implementation to use the `@graph` pattern with `@id`-based entity linking and added BreadcrumbList support across all pages. This improves SEO by enabling Google Rich Results (breadcrumb display) and provides better entity graph consistency for search engines and LLMs.

## Key Changes

- **New structured data module** (`src/lib/structured-data.ts`): Created reusable helper functions for generating schema.org entities with consistent `@id` patterns:
  - `createWebSiteEntity()` - WebSite entity with canonical @id
  - `createPersonEntity()` - Person entity for author/publisher
  - `createWebPageEntity()` - Generic WebPage wrapper
  - `createCollectionPageEntity()` - For collection/list pages
  - `createProfilePageEntity()` - For profile pages
  - `createBlogPostingEntity()` - BlogPosting with full metadata
  - `createBreadcrumbList()` - BreadcrumbList for navigation hierarchy
  - `createGraphJsonLd()` - Wraps entities in @graph structure

- **Updated all page components** to use the new helpers:
  - `/` (home): WebSite + Person + WebPage
  - `/about`: WebSite + Person + ProfilePage + BreadcrumbList
  - `/blog`: WebSite + Person + CollectionPage + BreadcrumbList
  - `/blog/[slug]`: WebSite + Person + WebPage + BlogPosting + BreadcrumbList
  - `/blog/tags`: WebSite + Person + CollectionPage + BreadcrumbList
  - `/blog/tags/[tag]`: WebSite + Person + CollectionPage + BreadcrumbList

- **Updated JsonLd component** to accept both `WithContext<Thing>` and `Graph` types for flexibility

- **Added comprehensive E2E tests** validating:
  - Correct entity types present on each page
  - Proper @id references between entities
  - BreadcrumbList structure and item counts
  - Entity relationships (author, mainEntity, etc.)

- **Added ADR document** explaining the decision rationale, @id conventions, and consequences

## Implementation Details

- All entities use consistent `@id` patterns: `{BLOG_URL}{path}#{fragment}` (e.g., `https://thinceller.net/#website`)
- BreadcrumbList items include Home → current page hierarchy
- BlogPosting references Person via `@id` instead of inline definition
- All entities include `inLanguage: 'ja'` for proper language tagging
- Maintains type safety with `schema-dts` library throughout

https://claude.ai/code/session_013SHAB2hmcrPwFFwL3XsU7p