### PR TITLE
chore(deps): upgrade pnpm to v11.11.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-save-exact=true

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "textlint-rule-spellcheck-tech-word": "5.0.0",
     "typescript": "5.9.3"
   },
-  "packageManager": "pnpm@10.34.4+sha512.8768be55200ae3f2226b6527fcca2687e14bc4e5f12d7721a0f25da3df47915177058648db4177baf348120fa0ba2752d8d8d93f6beaf1fe64ae18da8de961af",
+  "packageManager": "pnpm@11.11.0+sha512.4463f65fd80ed80d69bc1d4bf163ee94f605c7380fc318bb5b2ebe15f8cd12d49c51a4d59e951b401e764d3b6ca751cbf51bc50ed7001a6bcb4935e684c34882",
   "scripts": {
     "build": "next build",
     "build:analyze": "next experimental-analyze",
@@ -58,12 +58,5 @@
     "typecheck": "tsc --noEmit",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@tailwindcss/oxide",
-      "@vercel/speed-insights",
-      "sharp"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  "@tailwindcss/oxide": true
+  "@vercel/speed-insights": true
+  sharp: true
+saveExact: true


### PR DESCRIPTION
## 概要

pnpm を v10.34.4 から v11.11.0 にアップグレードする。

## 変更内容

- `packageManager` を `pnpm@11.11.0+sha512.…` に更新（ハッシュは npm registry の `dist.integrity` から検算済み）
- pnpm v11 は package.json の `pnpm` フィールドを読まなくなったため、`onlyBuiltDependencies` を `pnpm-workspace.yaml` の `allowBuilds` マップへ移行
- `.npmrc` は v11 で認証・レジストリ設定専用になったため、`save-exact=true` を `pnpm-workspace.yaml` の `saveExact: true` へ移行し、空になった `.npmrc` を削除

`pnpm-lock.yaml` は差分なし（lockfileVersion 9.0 は v11 でも据え置き）。

## 検証

- `pnpm --version` → 11.11.0（packageManager フィールド経由の自己管理）
- `pnpm install` → 警告なし、supply-chain policies 検証通過
- `pnpm lint` / `pnpm format` / `pnpm build`（35/35 ページ生成）/ `pnpm typecheck` すべて成功

## レビュアー向け注意点

- **Vercel**: 自動検出は pnpm 10 までのため、マージ前に Vercel プロジェクトの環境変数に `ENABLE_EXPERIMENTAL_COREPACK=1` を追加する必要がある（[Vercel Package Managers](https://vercel.com/docs/package-managers) 参照）。未設定だと lockfile ベースの推測で古い pnpm が選ばれるリスクあり
- **CI**: `pnpm/action-setup@v6` は `packageManager` フィールドを読むため変更不要。ただし [pnpm/action-setup#225](https://github.com/pnpm/action-setup/issues/225) の既知バグがあるため、CI ログでインストールされたバージョンを要確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)