### PR TITLE
fix(ci): review-prワークフローの失敗を可視化しbot PRをレビュー対象にする

### DIFF
--- a/.github/workflows/review-pr.yml
+++ b/.github/workflows/review-pr.yml
@@ -32,7 +32,6 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "claude"
-          show_full_output: true
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/review-pr.yml
+++ b/.github/workflows/review-pr.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
       id-token: write
     steps:
       - name: Checkout repository
@@ -30,6 +31,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "claude"
+          show_full_output: true
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -167,8 +170,67 @@ jobs:
           claude_args: |
             --allowedTools "Bash(gh api:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Write,Grep,Glob,Agent"
 
+      - name: Report review failure
+        id: report
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REVIEW_OUTCOME: ${{ steps.review.outcome }}
+          EXECUTION_FILE: ${{ steps.review.outputs.execution_file }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ISSUE_TITLE: Claude 自動レビューが失敗しています
+        run: |
+          errored=false
+          error_detail=""
+          if [ "$REVIEW_OUTCOME" = 'failure' ]; then
+            errored=true
+          elif [ -z "$EXECUTION_FILE" ] || [ ! -f "$EXECUTION_FILE" ]; then
+            errored=true
+            error_detail="execution_file not found"
+          elif jq -e '.[] | select(.type == "result" and .is_error == true)' "$EXECUTION_FILE" > /dev/null; then
+            errored=true
+            error_detail=$(jq -r '[.[] | select(.type == "result") | .result // empty] | join("\n")' "$EXECUTION_FILE" | head -c 500)
+          fi
+          echo "errored=$errored" >> "$GITHUB_OUTPUT"
+          issue_number=$(gh issue list --repo "$REPO" --state open \
+            --search "in:title \"$ISSUE_TITLE\"" \
+            --json number,title \
+            --jq ".[] | select(.title == \"$ISSUE_TITLE\") | .number" | head -n 1)
+          if [ "$errored" = "true" ]; then
+            echo "::warning::Automated review failed (review step outcome: $REVIEW_OUTCOME)"
+            {
+              echo "Claude 自動レビューが失敗しています。"
+              echo ""
+              echo "- workflow: review-pr"
+              echo "- 失敗した run: $RUN_URL"
+              echo "- PR: #$PR_NUMBER"
+              if [ -n "$error_detail" ]; then
+                echo ""
+                echo '```'
+                echo "$error_detail"
+                echo '```'
+              fi
+              echo ""
+              echo "最終更新: $(date -u)"
+            } > /tmp/review-failure-issue.md
+            if [ -n "$issue_number" ]; then
+              gh issue edit "$issue_number" --repo "$REPO" \
+                --body-file /tmp/review-failure-issue.md
+            else
+              gh issue create --repo "$REPO" --title "$ISSUE_TITLE" \
+                --body-file /tmp/review-failure-issue.md
+            fi
+          elif [ -n "$issue_number" ]; then
+            gh issue close "$issue_number" --repo "$REPO" \
+              --comment "自動レビューが回復しました: $RUN_URL"
+          fi
+
       - name: Clean up previous review artifacts
-        if: steps.review.outcome == 'success'
+        if: >-
+          steps.review.outcome == 'success' &&
+          steps.report.outputs.errored != 'true'
         continue-on-error: true
         uses: actions/github-script@v9
         with:


### PR DESCRIPTION
## 背景

2026-07-11以降、review-pr / review-deps の自動レビューが全滅していた（レビューが投稿されない）にもかかわらず、全runが緑チェックのままだった。

調査の結果、直接原因は **`CLAUDE_CODE_OAUTH_TOKEN` の有効期限切れ**（2025-07-10発行、`claude setup-token` のトークンは有効期限1年。失効直後から同トークンを使う全実行が「init直後・1ターン・$0・約2秒・is_error: true」で失敗）。

気づけなかった原因は二重マスク:
1. レビューstepの `continue-on-error: true`
2. claude-code-action が result `is_error: true` でも exit 0 する挙動（upstreamバグ）

さらに `show_full_output` がデフォルトfalseのため、エラー本文がログに一切出ず原因調査も困難だった（debug再実行でも出ない）。

## 変更内容

- **`show_full_output: true` を追加**: 失敗時のエラー本文がログに残り、診断可能になる（レビュー結果はどのみちPRに公開投稿されるためリスクは低い）
- **「Report review failure」stepを追加**: レビュー失敗（step失敗 / execution_file不存在 / result の is_error: true）を検知したら、**単一のトラッキングissue**で通知する
  - 固定タイトル「Claude 自動レビューが失敗しています」のopen issueをタイトル完全一致で検索し、無ければ作成（通知は初回の1回のみ）、あればbodyを最新のrun URL・エラー本文で更新（通知なし）
  - レビュー回復時はissueを自動クローズ
  - ジョブは落とさない（advisoryなレビューという設計意図を維持。PRに赤×は付かない）
  - 通知step自体も `continue-on-error: true`（通知手段の失敗で本体を汚さない）
- **cleanupの条件強化**: レビューが実質失敗した場合は旧レビューのdismissをスキップ
- **`allowed_bots: "claude"` を追加**: claude botが作成したPRはactionのactor検証で常に拒否されていた（`Workflow initiated by non-human actor: claude (type: Bot)`）ため、レビュー対象にする
- **`permissions` に `issues: write` を追加**（issueの作成・更新・クローズに必要）

## レビュー時の注意

- **このPRだけでは自動レビューは復旧しない**。`claude setup-token` でトークンを再発行し、`CLAUDE_CODE_OAUTH_TOKEN` secretの更新が別途必要
- issueのタイトルはreview-deps.ymlと将来共用する想定（bodyにworkflow名を明記）。ただし現状はreview-pr側だけが自動クローズを行うため、両方に展開するまでは「review-depsが壊れたままでもreview-pr回復時にissueが閉じる」可能性がある
- review-deps.ymlにも同じ隠蔽問題があるが、本PRのスコープ外（別途対応予定）
- 失敗判定・issue分岐ロジックはghをモックしたbash直接実行で検証済み。actionlint通過済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)