### PR TITLE
fix(ci): review-depsワークフローの失敗を可視化しreport stepをcomposite actionに共通化

### DIFF
--- a/.github/actions/report-review-failure/action.yml
+++ b/.github/actions/report-review-failure/action.yml
@@ -1,0 +1,85 @@
+name: Report review failure
+description: レビュー step の実質的な失敗を判定し、失敗時は issue を作成/更新、回復時はクローズする
+
+inputs:
+  workflow-name:
+    description: issue body に記載する workflow 名
+    required: true
+  review-outcome:
+    description: レビュー step の outcome
+    required: true
+  execution-file:
+    description: claude-code-action の execution_file output
+    required: false
+    default: ''
+  pr-number:
+    description: PR 番号
+    required: true
+  github-token:
+    description: issue 操作用トークン
+    required: true
+
+outputs:
+  errored:
+    description: レビューが実質的に失敗していたか
+    value: ${{ steps.report.outputs.errored }}
+
+runs:
+  using: composite
+  steps:
+    - id: report
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        WORKFLOW_NAME: ${{ inputs.workflow-name }}
+        REVIEW_OUTCOME: ${{ inputs.review-outcome }}
+        EXECUTION_FILE: ${{ inputs.execution-file }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        REPO: ${{ github.repository }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        ISSUE_TITLE: Claude 自動レビューが失敗しています
+      run: |
+        errored=false
+        error_detail=""
+        if [ "$REVIEW_OUTCOME" = 'failure' ]; then
+          errored=true
+        elif [ -z "$EXECUTION_FILE" ] || [ ! -f "$EXECUTION_FILE" ]; then
+          errored=true
+          error_detail="execution_file not found"
+        elif jq -e '.[] | select(.type == "result" and .is_error == true)' "$EXECUTION_FILE" > /dev/null; then
+          errored=true
+          error_detail=$(jq -r '[.[] | select(.type == "result") | .result // empty] | join("\n")' "$EXECUTION_FILE" | head -c 500)
+        fi
+        echo "errored=$errored" >> "$GITHUB_OUTPUT"
+        issue_number=$(gh issue list --repo "$REPO" --state open \
+          --search "in:title \"$ISSUE_TITLE\"" \
+          --json number,title \
+          --jq ".[] | select(.title == \"$ISSUE_TITLE\") | .number" | head -n 1)
+        if [ "$errored" = "true" ]; then
+          echo "::warning::Automated review failed (review step outcome: $REVIEW_OUTCOME)"
+          {
+            echo "Claude 自動レビューが失敗しています。"
+            echo ""
+            echo "- workflow: $WORKFLOW_NAME"
+            echo "- 失敗した run: $RUN_URL"
+            echo "- PR: #$PR_NUMBER"
+            if [ -n "$error_detail" ]; then
+              echo ""
+              echo '```'
+              echo "$error_detail"
+              echo '```'
+            fi
+            echo ""
+            echo "最終更新: $(date -u)"
+          } > /tmp/review-failure-issue.md
+          if [ -n "$issue_number" ]; then
+            gh issue edit "$issue_number" --repo "$REPO" \
+              --body-file /tmp/review-failure-issue.md
+          else
+            gh issue create --repo "$REPO" --title "$ISSUE_TITLE" \
+              --body-file /tmp/review-failure-issue.md
+          fi
+        elif [ -n "$issue_number" ]; then
+          gh issue close "$issue_number" --repo "$REPO" \
+            --comment "自動レビューが回復しました: $RUN_URL"
+        fi

--- a/.github/workflows/review-deps.yml
+++ b/.github/workflows/review-deps.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
       id-token: write
     steps:
       - name: Checkout repository
@@ -79,8 +80,21 @@ jobs:
           claude_args: |
             --allowedTools "Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Write,Grep,Glob,WebSearch,WebFetch"
 
+      - name: Report review failure
+        id: report
+        continue-on-error: true
+        uses: ./.github/actions/report-review-failure
+        with:
+          workflow-name: review-deps
+          review-outcome: ${{ steps.review.outcome }}
+          execution-file: ${{ steps.review.outputs.execution_file }}
+          pr-number: ${{ github.event.pull_request.number }}
+          github-token: ${{ github.token }}
+
       - name: Clean up previous review artifacts
-        if: steps.review.outcome == 'success'
+        if: >-
+          steps.review.outcome == 'success' &&
+          steps.report.outputs.errored != 'true'
         continue-on-error: true
         uses: actions/github-script@v9
         with:

--- a/.github/workflows/review-pr.yml
+++ b/.github/workflows/review-pr.yml
@@ -172,59 +172,13 @@ jobs:
       - name: Report review failure
         id: report
         continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REVIEW_OUTCOME: ${{ steps.review.outcome }}
-          EXECUTION_FILE: ${{ steps.review.outputs.execution_file }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          ISSUE_TITLE: Claude 自動レビューが失敗しています
-        run: |
-          errored=false
-          error_detail=""
-          if [ "$REVIEW_OUTCOME" = 'failure' ]; then
-            errored=true
-          elif [ -z "$EXECUTION_FILE" ] || [ ! -f "$EXECUTION_FILE" ]; then
-            errored=true
-            error_detail="execution_file not found"
-          elif jq -e '.[] | select(.type == "result" and .is_error == true)' "$EXECUTION_FILE" > /dev/null; then
-            errored=true
-            error_detail=$(jq -r '[.[] | select(.type == "result") | .result // empty] | join("\n")' "$EXECUTION_FILE" | head -c 500)
-          fi
-          echo "errored=$errored" >> "$GITHUB_OUTPUT"
-          issue_number=$(gh issue list --repo "$REPO" --state open \
-            --search "in:title \"$ISSUE_TITLE\"" \
-            --json number,title \
-            --jq ".[] | select(.title == \"$ISSUE_TITLE\") | .number" | head -n 1)
-          if [ "$errored" = "true" ]; then
-            echo "::warning::Automated review failed (review step outcome: $REVIEW_OUTCOME)"
-            {
-              echo "Claude 自動レビューが失敗しています。"
-              echo ""
-              echo "- workflow: review-pr"
-              echo "- 失敗した run: $RUN_URL"
-              echo "- PR: #$PR_NUMBER"
-              if [ -n "$error_detail" ]; then
-                echo ""
-                echo '```'
-                echo "$error_detail"
-                echo '```'
-              fi
-              echo ""
-              echo "最終更新: $(date -u)"
-            } > /tmp/review-failure-issue.md
-            if [ -n "$issue_number" ]; then
-              gh issue edit "$issue_number" --repo "$REPO" \
-                --body-file /tmp/review-failure-issue.md
-            else
-              gh issue create --repo "$REPO" --title "$ISSUE_TITLE" \
-                --body-file /tmp/review-failure-issue.md
-            fi
-          elif [ -n "$issue_number" ]; then
-            gh issue close "$issue_number" --repo "$REPO" \
-              --comment "自動レビューが回復しました: $RUN_URL"
-          fi
+        uses: ./.github/actions/report-review-failure
+        with:
+          workflow-name: review-pr
+          review-outcome: ${{ steps.review.outcome }}
+          execution-file: ${{ steps.review.outputs.execution_file }}
+          pr-number: ${{ github.event.pull_request.number }}
+          github-token: ${{ github.token }}
 
       - name: Clean up previous review artifacts
         if: >-


### PR DESCRIPTION
## 概要

- review-deps ワークフローにも #1343 と同じレビュー失敗の検知・報告を適用しました。anthropics/claude-code-action@v1 は result が `is_error: true` でも exit 0 する upstream バグがあるため、レビューが失敗してもジョブが緑のままになる問題への対応です
- あわせて、review-pr / review-deps で重複していた「Report review failure」step を composite action `.github/actions/report-review-failure` に共通化しました

## 変更内容

- **`.github/actions/report-review-failure/action.yml`（新規）**: review step の outcome と `execution_file` output から実質的な失敗を判定し、失敗時は固定タイトル「Claude 自動レビューが失敗しています」の issue を作成/body 更新、回復時は自動クローズする composite action。output `errored` を公開し、cleanup step のスキップ判定に利用
- **`review-pr.yml` / `review-deps.yml`**: インラインだった report step を composite action 呼び出しに置き換え。bash ロジックは純粋な移動で、変更は issue body の workflow 名のパラメータ化のみ
- **`review-deps.yml`**: permissions に `issues: write` を追加、cleanup step に `steps.report.outputs.errored != 'true'` 条件を追加（実質失敗時に前回レビューコメントの掃除を防ぐ）

## 補足

- issue タイトルは両ワークフローで共用のため、片方が回復するともう片方が壊れたままでも issue が閉じる制約があります（シンプルさ優先。分けたくなったら action の input 追加で対応可能）
- `show_full_output: true` は #1343 のレビュー指摘（公開リポジトリの Actions ログに全出力が出る懸念）に従い使用していません

## 検証

- `actionlint` を両ワークフローに実行しエラーなし
- composite action から抽出した bash を gh モックで 5 ケース実行し、失敗判定・issue 作成/更新/クローズ/何もしない分岐がすべて期待通りであることを確認
- `pnpm lint && pnpm format` パス（TS コード変更なしのため typecheck / E2E はスキップ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)