### PR TITLE
chore(deps): upgrade typescript to v6.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "textlint-rule-preset-ja-spacing": "2.4.3",
     "textlint-rule-preset-ja-technical-writing": "12.0.2",
     "textlint-rule-spellcheck-tech-word": "5.0.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   },
   "packageManager": "pnpm@11.11.0+sha512.4463f65fd80ed80d69bc1d4bf163ee94f605c7380fc318bb5b2ebe15f8cd12d49c51a4d59e951b401e764d3b6ca751cbf51bc50ed7001a6bcb4935e684c34882",
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,7 +73,7 @@ importers:
         version: 5.1.0
       valibot:
         specifier: 1.4.2
-        version: 1.4.2(typescript@5.9.3)
+        version: 1.4.2(typescript@6.0.3)
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.16
@@ -110,7 +110,7 @@ importers:
         version: 8.5.16
       schema-dts:
         specifier: 2.0.0
-        version: 2.0.0(typescript@5.9.3)
+        version: 2.0.0(typescript@6.0.3)
       tailwindcss:
         specifier: 4.3.2
         version: 4.3.2
@@ -127,8 +127,8 @@ importers:
         specifier: 5.0.0
         version: 5.0.0(textlint@15.7.1)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
 packages:
 
@@ -3110,8 +3110,8 @@ packages:
     resolution: {integrity: sha512-q7QNVDGTdl702bVFiI5eY4l/HkgCM6at9KhcFbgUAzezHFbOVy4+0O/lCjsABEQwbZPravVfBIiBVGo89yzHFg==}
     engines: {node: '>= 0.4'}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -6385,13 +6385,13 @@ snapshots:
 
   scheduler@0.27.0: {}
 
-  schema-dts-lib@1.0.0(typescript@5.9.3):
+  schema-dts-lib@1.0.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  schema-dts@2.0.0(typescript@5.9.3):
+  schema-dts@2.0.0(typescript@6.0.3):
     dependencies:
-      schema-dts-lib: 1.0.0(typescript@5.9.3)
+      schema-dts-lib: 1.0.0(typescript@6.0.3)
     transitivePeerDependencies:
       - typescript
 
@@ -7025,7 +7025,7 @@ snapshots:
       typed-array-buffer: 1.0.3
       typed-array-byte-offset: 1.0.4
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   ufo@1.6.3: {}
 
@@ -7135,9 +7135,9 @@ snapshots:
 
   uuid@11.1.0: {}
 
-  valibot@1.4.2(typescript@5.9.3):
+  valibot@1.4.2(typescript@6.0.3):
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   validate-npm-package-license@3.0.4:
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## 概要

TypeScript を 5.9.3 から 6.0.3（6.x系の最新安定版）にアップグレードします。

## 変更内容

- `typescript` 5.9.3 → 6.0.3
- `tsconfig.json`: `target: es5` → `es2017`
  - TS 6.0 で `target: es5` が非推奨化され、`tsc` がエラー（TS5107）になるための対応
  - 本プロジェクトは `noEmit` でトランスパイルは Next.js（SWC/Turbopack）が担うため、型チェックにのみ影響しビルド成果物は変わらない
  - `es2017` は Next.js（create-next-app）の標準生成値に合わせた選択

## 互換性の確認

- **Next.js 16.2**: 公式アップグレードガイドで TS 6 対応が明記済み。ビルド・静的生成とも問題なし
- **valibot**: peerDependency `typescript >=5` で 6.0 を許容
- **Biome / Playwright / textlint / Tailwind**: TypeScript コンパイラに依存せず影響なし
- その他の TS 6.0 破壊的変更（`moduleResolution: node10` 廃止、`baseUrl` 非推奨、`esModuleInterop: false` 禁止など）は本プロジェクトの設定に該当せず

## TypeScript 7.0 について

npm の latest は既に 7.0.2（Go実装ネイティブ版）ですが、Next.js 16.2 が build 時型チェックに TS の JavaScript API を必要とするため、7.0 では `next build` が失敗することを検証済み（[vercel/next.js#81472](https://github.com/vercel/next.js/discussions/81472) で対応議論中）。6.0 で非推奨オプションを解消済みのため、Next.js 対応後はバージョン変更のみで 7.0 へ移行可能な見込み。

## 検証

- `pnpm lint` / `pnpm format` / `pnpm typecheck` / `pnpm build` すべて通過
- Playwright E2E テスト 12件すべて通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)