### PR TITLE
fix(blog): タグ一覧ページのタグリンク先URLを修正

### DIFF
--- a/src/app/blog/tags/page.tsx
+++ b/src/app/blog/tags/page.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
   description: 'すべてのタグの一覧',
   openGraph: {
     type: 'website',
-    url: '/tags',
+    url: '/blog/tags',
     title: `タグ一覧 | ${BLOG_NAME}`,
     description: 'すべてのタグの一覧',
     siteName: BLOG_NAME,
@@ -61,7 +61,7 @@ export default function Page() {
           {sortedTags.map(([tag, count]) => (
             <Link
               key={tag}
-              href={`/tags/${encodeURIComponent(tag)}`}
+              href={`/blog/tags/${encodeURIComponent(tag)}`}
               className="flex items-center justify-between p-4 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
             >
               <span className="text-lg">


### PR DESCRIPTION
## 概要

タグ一覧ページ (`/blog/tags`) の各タグのリンク先が `/tags/[tag]` になっており、実際のルート `/blog/tags/[tag]` と一致していなかったため、タグをクリックすると 404 になっていました。

## 変更内容

`src/app/blog/tags/page.tsx`:

- タグリンクの `href` を `/tags/${tag}` → `/blog/tags/${tag}` に修正
- あわせて `metadata.openGraph.url` も `/tags` → `/blog/tags` に修正

`src/components/PostTags.tsx`（記事内のタグリンク）や `src/app/blog/tags/sitemap.ts` はすでに `/blog/tags/...` を参照しており、これでサイト全体のタグURLが一致します。

## 確認

- `pnpm lint` / `pnpm format` / `pnpm typecheck` / `pnpm build` すべてパス
- ビルド出力で `/blog/tags/[tag]` が SSG されていることを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpzjN8cnMu8t4TFCgYVQTq)_