### PR TITLE
docs(readme): add managed by Hermes kanban worker line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # thinceller.net
+
+Managed by Hermes kanban worker


### PR DESCRIPTION
## 実装概要

- README.md の見出し直下に `Managed by Hermes kanban worker` を追加しました。
- タスクで指定されたファイルのみ変更しています。

## 検証結果

```bash
nix develop -c pnpm lint && nix develop -c pnpm format && nix develop -c pnpm typecheck
```

すべてパスしました。
- lint: `Checked 67 files in 54ms. No fixes applied.`
- format: `Checked 67 files in 90ms. No fixes applied.`
- typecheck: エラーなし

## 注意点

NixOS 上で @biomejs/biome のプリビルドバイナリが動的リンクエラーになるため、作業前に `patchelf` で interpreter を修正しました。これはローカルのバイナリに対する変更であり、リポジトリには含まれていません。